### PR TITLE
Add sprint Kanban markdown documents

### DIFF
--- a/docs/wiki/Sprint-1-Kanban.md
+++ b/docs/wiki/Sprint-1-Kanban.md
@@ -1,0 +1,97 @@
+# Sprint 1 Kanban Board
+
+**Sprint:** Sprint 1  
+**Period:** 23 Jan 2025 - 28 Jan 2025  
+**Sprint Theme:** Project scope definition, system analysis, architecture design, initial repository and wiki setup.  
+**Scrum Master:** Jingkun  
+**Product Owner:** Liheng
+
+---
+
+## Sprint Goal
+
+The goal of Sprint 1 is to establish the foundation of the Panda Scooter project. The team focuses on clarifying the product scope, identifying user roles, defining core requirements, preparing system design artefacts, and setting up the initial development/documentation environment.
+
+The deliverable of this sprint is not a complete runnable product, but a validated project foundation that allows the team to start implementation in Sprint 2 with clear requirements, architecture, responsibilities, and development direction.
+
+---
+
+## Kanban Summary
+
+| Status | Number of Items | Description |
+|---|---:|---|
+| Backlog | 3 | Items identified but not selected for Sprint 1 implementation. |
+| To Do | 0 | Sprint 1 tasks have been assigned and completed or moved forward. |
+| In Progress | 0 | No remaining active Sprint 1 implementation task at sprint close. |
+| Review / Verification | 2 | Items requiring team confirmation or minor refinement. |
+| Done | 12 | Main Sprint 1 planning, design and setup tasks completed. |
+
+---
+
+## Backlog
+
+| ID | Item | Owner | Priority | Notes |
+|---|---|---|---|---|
+| S1-B01 | Implement complete rental transaction workflow | Zhicheng / Chenhao | High | Moved to Sprint 2 because Sprint 1 focuses on requirement and design. |
+| S1-B02 | Implement administrator dashboard statistics | Chenhao / Liheng | Medium | Requires backend data model and frontend dashboard structure first. |
+| S1-B03 | Implement monthly subscription package purchase | Liheng / Zhicheng | Medium | Kept as a later feature after the basic ride flow is stable. |
+
+---
+
+## To Do
+
+| ID | Item | Owner | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| - | No remaining Sprint 1 task | - | - | Sprint 1 selected tasks have either been completed or moved to later sprints. |
+
+---
+
+## In Progress
+
+| ID | Item | Owner | Priority | Current Progress |
+|---|---|---|---|---|
+| - | No active Sprint 1 task | - | - | Sprint 1 is treated as a completed planning/design sprint. |
+
+---
+
+## Review / Verification
+
+| ID | Item | Owner | Priority | Verification Evidence / Next Action |
+|---|---|---|---|---|
+| S1-R01 | Confirm consistency between use case, activity, class and ER diagrams | Kecen / Chenhao | High | Team review required to ensure that system behaviour and data model are aligned. |
+| S1-R02 | Confirm UI wireframe flow before implementation | Liheng / Zhicheng | High | Product Owner and frontend team should confirm user, dispatcher and admin journeys. |
+
+---
+
+## Done
+
+| ID | Item | Owner | Priority | Completion Evidence |
+|---|---|---|---|---|
+| S1-D01 | Define dockless scooter sharing product scope | Liheng | High | Scope defined around free-floating scooter rental within allowed city zones. |
+| S1-D02 | Identify core user roles | Liheng / Jingkun | High | Three roles defined: rider/user, operational manager/dispatcher, administrator. |
+| S1-D03 | Define rider-side functional requirements | Liheng / Zhicheng | High | Login/register, map display, rent scooter, return scooter, payment, fault reporting, usage statistics and monthly subscription identified. |
+| S1-D04 | Define operational manager requirements | Kecen / Chenhao | High | Manager login, faulty vehicle view, remote unlock and operational statistics identified. |
+| S1-D05 | Define administrator requirements | Chenhao / Liheng | High | Pricing management, analytics, subscription package management, zone definition and staff assignment identified. |
+| S1-D06 | Create initial GitHub Wiki structure | Jingkun | High | Wiki navigation and project documentation structure created. |
+| S1-D07 | Prepare initial project backlog and issue management plan | Jingkun | High | GitHub Wiki and Issues selected as project management tools. |
+| S1-D08 | Design use case diagram | Kecen | High | Use case modelling assigned and prepared for system behaviour documentation. |
+| S1-D09 | Design activity diagram | Kecen | Medium | Activity flow modelling assigned for main user/system processes. |
+| S1-D10 | Design deployment diagram | Kecen | Medium | Deployment modelling assigned to describe client-server architecture. |
+| S1-D11 | Design class diagram and ER diagram | Chenhao | High | Backend design artefacts assigned to support later implementation. |
+| S1-D12 | Prepare UniApp project direction and wireframes | Liheng / Zhicheng / Jingkun | High | UniApp selected for cross-platform user and manager apps; wireframe work assigned. |
+
+---
+
+## Sprint 1 Carry-over Items
+
+| Carry-over Item | Reason | Planned Follow-up |
+|---|---|---|
+| API details and endpoint definitions | Backend design needed to be stabilised first. | Complete API documentation during Sprint 2. |
+| Runnable frontend prototype | Wireframes and framework direction were prioritised first. | Build rider, dispatcher and admin interface skeletons in Sprint 2. |
+| End-to-end rental flow | Requires backend database, authentication and scooter state management. | Implement as Sprint 2 core MVP feature. |
+
+---
+
+## Sprint 1 Review Notes
+
+Sprint 1 successfully established the product direction and team responsibilities. The key outcome is that the team now has a shared understanding of system actors, main features, tools, and design responsibilities. The next sprint should move from planning artefacts to working software, with priority on authentication, scooter map display, basic ride lifecycle, and administrator/dispatcher management functions.

--- a/docs/wiki/Sprint-2-Kanban.md
+++ b/docs/wiki/Sprint-2-Kanban.md
@@ -1,0 +1,102 @@
+# Sprint 2 Kanban Board
+
+**Sprint:** Sprint 2  
+**Sprint Theme:** MVP implementation for authentication, map-based scooter usage, backend API, database integration and first runnable frontend modules.  
+**Main Focus:** Convert Sprint 1 requirements and design artefacts into working software.
+
+---
+
+## Sprint Goal
+
+The goal of Sprint 2 is to build the first usable MVP of Panda Scooter. Based on the Sprint 1 requirement analysis, Sprint 2 focuses on implementing the core technical foundation: backend service structure, database integration, authentication, rider-side map/rental workflow, dispatcher-side operational view, and initial administrator management pages.
+
+By the end of this sprint, the team should have a runnable system skeleton across backend, rider app, dispatcher app and admin dashboard, with the key end-to-end flow partially or fully demonstrable.
+
+---
+
+## Kanban Summary
+
+| Status | Number of Items | Description |
+|---|---:|---|
+| Backlog | 4 | Non-MVP or enhancement tasks postponed to Sprint 3. |
+| To Do | 2 | Remaining documentation and refinement tasks. |
+| In Progress | 4 | Features under implementation or integration. |
+| Review / Verification | 5 | Implemented modules requiring testing, code review or UI validation. |
+| Done | 10 | Core setup and initial MVP features completed. |
+
+---
+
+## Backlog
+
+| ID | Item | Owner | Priority | Notes |
+|---|---|---|---|---|
+| S2-B01 | Advanced dashboard analytics and data visualisation | Chenhao | Medium | Can be improved after basic admin CRUD and data collection are stable. |
+| S2-B02 | Monthly subscription package purchase workflow | Liheng / Zhicheng | Medium | Requires stable payment/rental foundation first. |
+| S2-B03 | Detailed ride history statistics and personal reports | Zhicheng | Medium | Depends on completed ride record persistence. |
+| S2-B04 | Full deployment optimisation with Nginx/MQTT production configuration | Jingkun | Medium | Basic deployment notes can be kept, but full deployment can be completed later. |
+
+---
+
+## To Do
+
+| ID | Item | Owner | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| S2-T01 | Update API documentation according to implemented backend endpoints | Jingkun / Chenhao | High | API document includes authentication, scooter, parking, ride and admin-related endpoints. |
+| S2-T02 | Prepare Sprint 2 review evidence | Jingkun | Medium | Screenshots, commits and demo notes are collected for the wiki review page. |
+
+---
+
+## In Progress
+
+| ID | Item | Owner | Priority | Current Progress / Acceptance Criteria |
+|---|---|---|---|---|
+| S2-P01 | Implement rider-side rent and return workflow | Zhicheng | High | User can select a scooter, start a ride, view riding state and return the scooter. |
+| S2-P02 | Implement dispatcher-side faulty vehicle and operational map workflow | Kecen | High | Dispatcher can view abnormal/faulty scooters and perform operational actions. |
+| S2-P03 | Implement admin-side parking point and zone management | Chenhao | High | Admin can create, edit, delete and view parking points/zones on the map. |
+| S2-P04 | Integrate frontend apps with backend API | Jingkun / All | High | User, dispatcher and admin apps communicate with the Spring Boot backend instead of mock data only. |
+
+---
+
+## Review / Verification
+
+| ID | Item | Owner | Priority | Verification Method |
+|---|---|---|---|---|
+| S2-R01 | Verify user login and registration | Liheng / Jingkun | High | Test normal login, registration, invalid password and token/session handling. |
+| S2-R02 | Verify map display and scooter marker rendering | Zhicheng | High | Test that scooters and parking points are displayed correctly on the map. |
+| S2-R03 | Verify backend database schema and MyBatis persistence | Chenhao | High | Confirm entities, DTO/VO objects and database tables match implemented workflows. |
+| S2-R04 | Verify administrator CRUD pages | Chenhao / Liheng | High | Check parking point, zone, scooter and staff management operations. |
+| S2-R05 | Verify cross-role navigation and page consistency | Jingkun | Medium | Check that rider, dispatcher and admin apps follow the agreed wireframes. |
+
+---
+
+## Done
+
+| ID | Item | Owner | Priority | Completion Evidence |
+|---|---|---|---|---|
+| S2-D01 | Create Spring Boot backend module structure | Jingkun / Chenhao | High | Backend organised into common, pojo and server modules. |
+| S2-D02 | Configure Java 17, Spring Boot, MyBatis and MySQL environment | Chenhao | High | Backend can connect to database and run locally. |
+| S2-D03 | Create initial database tables for users, scooters, rides and parking/zone data | Chenhao | High | Core entities required by MVP are represented in the database. |
+| S2-D04 | Implement JWT-based authentication foundation | Jingkun / Chenhao | High | Login-protected APIs can identify current user role. |
+| S2-D05 | Create rider UniApp project skeleton | Zhicheng | High | Rider app includes basic pages for login, map and ride flow. |
+| S2-D06 | Create dispatcher UniApp project skeleton | Kecen | High | Dispatcher app includes basic login and map/operation pages. |
+| S2-D07 | Create admin Vue 3 dashboard skeleton | Liheng / Chenhao | High | Admin dashboard includes layout, routing and initial management pages. |
+| S2-D08 | Configure map service integration | Zhicheng / Liheng | High | Frontend can display map view and location-related layers. |
+| S2-D09 | Implement basic scooter list/query API | Chenhao | High | Backend can return scooter and parking related data to frontend. |
+| S2-D10 | Establish team coding and commit workflow | Jingkun | Medium | Team follows shared repository workflow and keeps commits linked to tasks where possible. |
+
+---
+
+## Sprint 2 Carry-over Items
+
+| Carry-over Item | Reason | Planned Follow-up |
+|---|---|---|
+| Complete payment and subscription workflow | MVP ride flow has higher priority. | Implement or polish in Sprint 3. |
+| More robust dispatcher fault-handling workflow | Requires stable scooter state and fault record model. | Complete operational workflow and verification in Sprint 3. |
+| Full user statistics and admin analytics | Data needs to accumulate from ride and operation records. | Add dashboard charts and statistics in Sprint 3. |
+| Final deployment documentation | Implementation still changing. | Complete deployment and release documentation in Sprint 3. |
+
+---
+
+## Sprint 2 Review Notes
+
+Sprint 2 should be evaluated mainly by whether the team has moved from design to a working MVP. The most important evidence should include runnable frontend pages, successful backend API calls, database persistence, and a partial end-to-end demonstration from login to scooter query and ride operation. Any unfinished advanced functions should be explicitly carried into Sprint 3 instead of blocking the MVP review.

--- a/docs/wiki/Sprint-3-Kanban.md
+++ b/docs/wiki/Sprint-3-Kanban.md
@@ -1,0 +1,104 @@
+# Sprint 3 Kanban Board
+
+**Sprint:** Sprint 3  
+**Sprint Theme:** System integration, feature completion, testing, bug fixing, documentation and final demo preparation.  
+**Main Focus:** Turn the MVP into a more complete and presentable shared scooter system.
+
+---
+
+## Sprint Goal
+
+The goal of Sprint 3 is to complete the main user, dispatcher and administrator workflows, integrate the frontend and backend more reliably, fix defects found in Sprint 2, and prepare final project documentation and demonstration materials.
+
+By the end of this sprint, Panda Scooter should be presentable as a full-stack shared scooter platform with a clear rider workflow, dispatcher workflow, administrator workflow, database persistence, API documentation, wiki documentation and final demo evidence.
+
+---
+
+## Kanban Summary
+
+| Status | Number of Items | Description |
+|---|---:|---|
+| Backlog | 3 | Optional improvements beyond the final coursework/demo scope. |
+| To Do | 3 | Final documentation and polishing tasks. |
+| In Progress | 4 | Integration, testing and feature completion tasks. |
+| Review / Verification | 6 | Final validation before demo/submission. |
+| Done | 11 | Completed implementation and documentation outcomes. |
+
+---
+
+## Backlog
+
+| ID | Item | Owner | Priority | Notes |
+|---|---|---|---|---|
+| S3-B01 | Real-time vehicle telemetry through physical IoT hardware | Jingkun | Low | Current version can use simulated scooter/device state. |
+| S3-B02 | Advanced recommendation for scooter redistribution | Kecen / Chenhao | Low | Useful future work, but beyond the core shared-scooter MVP. |
+| S3-B03 | Production-grade payment integration | Liheng / Zhicheng | Medium | Demo can use simulated payment status if external payment integration is not required. |
+
+---
+
+## To Do
+
+| ID | Item | Owner | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| S3-T01 | Finalise project README and quick-start guide | Jingkun | High | README clearly explains tech stack, project structure, startup commands and main functions. |
+| S3-T02 | Complete Sprint 3 Review page and retrospective notes | Jingkun / All | Medium | Wiki contains final sprint outcome, screenshots, remaining limitations and lessons learned. |
+| S3-T03 | Prepare final demo script and presentation flow | Liheng / Jingkun | High | Demo covers rider, dispatcher and admin workflows in a logical order. |
+
+---
+
+## In Progress
+
+| ID | Item | Owner | Priority | Current Progress / Acceptance Criteria |
+|---|---|---|---|---|
+| S3-P01 | Complete end-to-end ride lifecycle integration | Zhicheng / Chenhao | High | User can complete login, scooter selection, unlock/rent, ride status update and return process. |
+| S3-P02 | Complete dispatcher fault-handling and remote operation workflow | Kecen | High | Dispatcher can view faulty scooters, inspect details and perform remote operational actions. |
+| S3-P03 | Complete administrator management workflow | Chenhao / Liheng | High | Admin can manage scooter, parking point, zone, dispatcher/staff and pricing/subscription information. |
+| S3-P04 | Fix frontend-backend integration bugs | Jingkun / All | High | Major API, routing, token and data-format bugs are resolved before final demo. |
+
+---
+
+## Review / Verification
+
+| ID | Item | Owner | Priority | Verification Method |
+|---|---|---|---|---|
+| S3-R01 | Verify complete rider workflow | Zhicheng / Jingkun | High | Demonstrate register/login, map view, rent, return, payment/status and ride record behaviour. |
+| S3-R02 | Verify complete dispatcher workflow | Kecen | High | Demonstrate faulty scooter query, operational map view and remote unlock/management action. |
+| S3-R03 | Verify complete administrator workflow | Liheng / Chenhao | High | Demonstrate dashboard, parking point, zone, scooter and staff management pages. |
+| S3-R04 | Verify API documentation and backend consistency | Chenhao / Jingkun | High | Documented API endpoints match actual implemented request/response behaviour. |
+| S3-R05 | Verify database persistence and data consistency | Chenhao | High | Data changes from frontend operations are persisted and can be queried correctly. |
+| S3-R06 | Verify final UI consistency and usability | Liheng / Zhicheng | Medium | Pages follow wireframes, navigation is clear, and the demo process is smooth. |
+
+---
+
+## Done
+
+| ID | Item | Owner | Priority | Completion Evidence |
+|---|---|---|---|---|
+| S3-D01 | Complete multi-role system structure | All | High | User app, dispatcher app and admin app are connected to the shared backend. |
+| S3-D02 | Complete rider-side map-based scooter discovery | Zhicheng | High | Rider can view scooters and parking-related information on map. |
+| S3-D03 | Complete backend service and controller structure | Chenhao / Jingkun | High | Backend exposes APIs for authentication, scooters, rides, parking/zone and management data. |
+| S3-D04 | Complete database integration | Chenhao | High | MySQL persistence is used for key business entities. |
+| S3-D05 | Complete admin dashboard skeleton and major management pages | Liheng / Chenhao | High | Admin UI supports core management workflow. |
+| S3-D06 | Complete dispatcher basic operational interface | Kecen | High | Dispatcher UI supports operational map and fault/vehicle handling entry points. |
+| S3-D07 | Add or update API documentation | Jingkun / Chenhao | High | API documentation can support review and future maintenance. |
+| S3-D08 | Add or update GitHub Wiki project documentation | Jingkun | Medium | Wiki contains sprint planning/review, wireframes, API documentation and meeting/project notes. |
+| S3-D09 | Improve README project introduction | Jingkun | Medium | README describes project structure, technology stack, features, architecture and quick start. |
+| S3-D10 | Prepare final testing checklist | All | Medium | Main functional paths are tested before demo. |
+| S3-D11 | Prepare final project demo materials | Liheng / Jingkun | High | Demo route and screenshots/video materials are ready for assessment. |
+
+---
+
+## Final Bug / Risk List
+
+| Risk / Bug | Impact | Mitigation |
+|---|---|---|
+| Map service key or network issue | Demo map may fail to load. | Prepare screenshots/video and local fallback data. |
+| Frontend-backend API field mismatch | Pages may not render expected data. | Freeze request/response format before final demo and update API documentation. |
+| Database seed data missing | Demo may lack scooters, zones or users. | Prepare initial SQL or manual seed data before presentation. |
+| Role-based access not fully enforced | Users may access incorrect pages/API. | Add simple frontend route guards and backend token/role checks where possible. |
+
+---
+
+## Sprint 3 Review Notes
+
+Sprint 3 should focus on final integration and evidence. The review should show the project as a coherent product rather than isolated pages. The recommended demo order is: rider login and scooter rental, dispatcher operational handling, administrator management, then backend/API/database explanation. Remaining limitations should be described as future work instead of hidden, especially physical scooter integration, real payment service and production-grade deployment.


### PR DESCRIPTION
## Summary

This PR adds three Markdown Kanban board documents for the Panda Scooter project:

- `docs/wiki/Sprint-1-Kanban.md`
- `docs/wiki/Sprint-2-Kanban.md`
- `docs/wiki/Sprint-3-Kanban.md`

## Content covered

- Sprint goal and theme
- Kanban status summary
- Backlog / To Do / In Progress / Review / Done sections
- Carry-over items and review notes
- Final bug/risk list for Sprint 3

The content is based on the current GitHub Wiki project scope and the repository README implementation structure, including user, dispatcher and administrator workflows, Spring Boot backend, UniApp frontends, Vue admin dashboard, MySQL, map services and related documentation tasks.

## Notes

The wiki repository itself is separate from the main repository, so these Markdown files are placed under `docs/wiki/` first. They can be copied into GitHub Wiki pages later if needed.